### PR TITLE
사용자 정보 변경 popup 구현 및 API 연동 완료

### DIFF
--- a/src/api/url.js
+++ b/src/api/url.js
@@ -17,7 +17,7 @@ export const FOLLOW_USER = "/follow/create";
 export const UN_FOLLOW_USER = "/follow/delete";
 
 // 사용자 정보 변경
-export const UPDATE_USER = "/settings/upload-user";
+export const UPDATE_USER = "/settings/update-user";
 export const UPDATE_PASSWORD = "/settings/update-password";
 
 // 채널
@@ -58,3 +58,9 @@ export const GET_CONVERSATION = "/messages/conversations";
 export const GET_MESSAGES = "/messages";
 export const CREATE_MESSAGES = "/messages/create";
 export const SEEN_MESSAGES = "/messages/update-seen";
+
+// 공통 default url
+export const DEFAULT_COVER_IMAGE =
+  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Default+Cover+Image.png";
+export const DEFAULT_PROFILE_IMAGE =
+  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Profile_Image.png";

--- a/src/api/user-api.js
+++ b/src/api/user-api.js
@@ -8,6 +8,8 @@ import {
   GET_USER_DATA_BY_ID,
   FOLLOW_USER,
   UN_FOLLOW_USER,
+  UPDATE_USER,
+  UPDATE_PASSWORD,
 } from "./url";
 
 export const getUsers = async (offset, limit) => {
@@ -78,4 +80,50 @@ export const unFollowUser = async (id, token) => {
     },
   });
   return res;
+};
+
+/**
+ * 사용자 정보 중 full Name 변경 API
+ * @param {*} token 사용자 id token
+ * @param {*} fullName 사용자 fullname
+ * @param {*} username 사용자 email
+ */
+export const modifyUserInfo = async (token, fullName, username) => {
+  if (!token) throw Exception("token 정보가 존재하지 않습니다.");
+
+  const res = await axios.put(
+    `${BASE_URL}${UPDATE_USER}`,
+    {
+      fullName,
+      username,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  return res;
+};
+
+/**
+ * 사용자 정보 중 비밀번호 변경 API
+ * @param {*} token 사용자 id token
+ * @param {*} password 변경할 비밀번호
+ */
+export const modifyPassword = async (token, password) => {
+  if (!token) throw Exception("token 정보가 존재하지 않습니다.");
+
+  await axios.put(
+    `${BASE_URL}${UPDATE_PASSWORD}`,
+    {
+      password,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
 };

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -16,6 +16,7 @@ const propTypes = {
   type: PropTypes.string,
   props: PropTypes.instanceOf(Object),
   onClick: PropTypes.func,
+  style: PropTypes.instanceOf(Object),
 };
 
 const defaultProps = {
@@ -29,6 +30,7 @@ const defaultProps = {
   type: "button",
   props: {},
   onClick: () => {},
+  style: {},
 };
 
 const Button = ({
@@ -61,7 +63,12 @@ const Button = ({
   };
 
   return (
-    <SButton style={buttonStyle} type={type} onClick={onClick} {...props}>
+    <SButton
+      {...props}
+      style={{ ...buttonStyle, ...props.style }}
+      type={type}
+      onClick={onClick}
+    >
       <Text size={textSize} color={color} strong>
         {children}
       </Text>

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { NavLink, useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
@@ -8,6 +8,7 @@ import Icon from "components/Icon";
 import Popup from "components/Popup";
 import Alarm from "components/Alarm";
 import SideBar from "components/SideBar";
+import useQuery from "hooks/useQuery";
 import { userInfo } from "recoil/user";
 import { loginStatus, logoutProcess } from "../../recoil/authentication";
 import * as Ns from "./Navigation.style";
@@ -122,6 +123,7 @@ NavButtonBlock.defaultProps = {
 
 function Navigation() {
   // 사용자 리스트 사이드 바 hide / show flag
+  const query = useQuery();
   const [sideBarShow, setSideBarShow] = useState(false);
   const [modalStatus, setModalStatus] = useState({
     visible: false,
@@ -136,6 +138,15 @@ function Navigation() {
       type,
     });
   };
+
+  useEffect(() => {
+    if (query.get("needLogin") != null) {
+      setModalStatus({
+        visible: true,
+        type: "login",
+      });
+    }
+  }, [query]);
 
   return (
     <>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,3 +17,4 @@ export { default as Spinner } from "./Spinner";
 export { default as PostListInput } from "./PostListInput";
 export { default as Dot } from "./Dot";
 export { default as Divider } from "./Divider";
+export { default as Modal } from "./Modal";

--- a/src/hooks/useQuery.js
+++ b/src/hooks/useQuery.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+const useQuery = () => {
+  const { search } = useLocation();
+
+  return React.useMemo(() => new URLSearchParams(search), [search]);
+};
+
+export default useQuery;

--- a/src/pages/UserPage/UserPage.style.js
+++ b/src/pages/UserPage/UserPage.style.js
@@ -57,3 +57,17 @@ export const FollowBlock = styled.div`
 `;
 
 export const Main = styled.div``;
+
+export const UserNameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  .material-symbols-outlined {
+    display: none;
+    cursor: pointer;
+  }
+
+  &:hover .material-symbols-outlined {
+    display: block;
+  }
+`;

--- a/src/pages/UserPage/components/ModifyUserInfo/ModifyPassword.js
+++ b/src/pages/UserPage/components/ModifyUserInfo/ModifyPassword.js
@@ -1,0 +1,167 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { useForm } from "react-hook-form";
+import { userLogin, userLogout } from "api/auth-api";
+import { modifyPassword } from "api/user-api";
+import { Avatar, Button, Text } from "components";
+import { DEFAULT_PROFILE_IMAGE } from "api/url";
+import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import { logoutProcess } from "recoil/authentication";
+import * as S from "./ModifyUserInfo.style";
+
+const propTypes = {
+  token: PropTypes.string.isRequired,
+  user: PropTypes.instanceOf(Object).isRequired,
+  onClose: PropTypes.func,
+};
+const defaultProps = {
+  onClose: () => {},
+};
+
+const ModifyPassword = ({ token, user, onClose }) => {
+  const navigate = useNavigate();
+  const setLogout = useSetRecoilState(logoutProcess);
+  const [serverError, setServerError] = useState("");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm({
+    mode: "onSubmit",
+    defaultValues: {
+      currentPassword: "",
+      newPassword: "",
+      passwordConfirm: "",
+    },
+  });
+
+  const onSubmit = async (data) => {
+    const { currentPassword, newPassword } = data;
+
+    try {
+      setServerError("");
+      const { email } = user;
+      // 1. 로그인을 통해 사용자의 비밀번호가 맞는지 검사
+      const result = await userLogin(email, currentPassword);
+      if (result) {
+        // 2. 비밀번호가 일치한다면 사용자의 정보 변경
+        await modifyPassword(token, newPassword);
+        // 3. 비밀번호 변경이 성공했다면 강제 로그아웃
+        await userLogout();
+        await setLogout();
+        onClose();
+        // 4. 강제 로그아웃 성공 시, 메인페이지로 이동
+        navigate("/?needLogin=true");
+      }
+    } catch (exception) {
+      console.log(exception);
+      setServerError(
+        exception.response ? exception.response.data : "에러가 발생하였습니다."
+      );
+    }
+  };
+
+  return (
+    <S.Form onSubmit={handleSubmit(onSubmit)}>
+      <S.ProfileWrap>
+        <Avatar src={user.image || DEFAULT_PROFILE_IMAGE} size={150} />
+        <Text size="$b3" strong style={{ marginTop: 20 }}>
+          {user.fullName}
+        </Text>
+      </S.ProfileWrap>
+      <S.ModalInputWrap>
+        <S.ModalInput
+          {...register("currentPassword", {
+            required: { value: true, message: "현재 비밀번호를 입력해주세요!" },
+          })}
+          useIcon={false}
+          placeholder="현재 비밀번호를 입력해주세요."
+          width="100%"
+          type="password"
+        />
+        {errors.currentPassword && (
+          <S.ErrorMsg>{errors.currentPassword.message}</S.ErrorMsg>
+        )}
+      </S.ModalInputWrap>
+      <S.ModalInputWrap>
+        <S.ModalInput
+          {...register("newPassword", {
+            required: {
+              value: true,
+              message: "변경할 비밀번호를 입력해주세요!",
+            },
+            minLength: {
+              value: 8,
+              message: "최소 8자리 이상 입력해 주세요!",
+            },
+            maxLength: {
+              value: 12,
+              message: "최대 12자리 까지만 입력해 주세요!",
+            },
+            pattern: {
+              value:
+                /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]/,
+              message: "비밀번호는 알파벳, 특수문자, 숫자를 포함하여야 합니다",
+            },
+          })}
+          useIcon={false}
+          placeholder="변경할 비밀번호를 입력해주세요."
+          width="100%"
+          type="password"
+        />
+        {errors.newPassword && (
+          <S.ErrorMsg>{errors.newPassword.message}</S.ErrorMsg>
+        )}
+      </S.ModalInputWrap>
+      <S.ModalInputWrap>
+        <S.ModalInput
+          {...register("passwordConfirm", {
+            required: {
+              value: true,
+              message: "비밀번호가 일치하지 않습니다.",
+            },
+            validate: (value) =>
+              value === watch("newPassword") || "비밀번호가 일치하지 않습니다.",
+          })}
+          useIcon={false}
+          placeholder="변경할 비밀번호를 다시 적어주세요."
+          width="100%"
+          type="password"
+        />
+        {errors.passwordConfirm && (
+          <S.ErrorMsg>{errors.passwordConfirm.message}</S.ErrorMsg>
+        )}
+      </S.ModalInputWrap>
+      <S.ErrorMsg>{serverError}</S.ErrorMsg>
+      <div>
+        <Button
+          type="submit"
+          width={90}
+          height={45}
+          style={{ display: "inline-block", float: "right", marginLeft: 10 }}
+        >
+          저장
+        </Button>
+        <Button
+          type="button"
+          width={90}
+          height={45}
+          color="$main"
+          backgroundColor="$bg_white"
+          border
+          onClick={onClose}
+          style={{ display: "inline-block", float: "right" }}
+        >
+          취소
+        </Button>
+      </div>
+    </S.Form>
+  );
+};
+
+ModifyPassword.propTypes = propTypes;
+ModifyPassword.defaultProps = defaultProps;
+
+export default ModifyPassword;

--- a/src/pages/UserPage/components/ModifyUserInfo/ModifyUserInfo.style.js
+++ b/src/pages/UserPage/components/ModifyUserInfo/ModifyUserInfo.style.js
@@ -1,0 +1,41 @@
+import styled from "@emotion/styled";
+import { Input } from "components";
+import Common from "styles/common";
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+export const ProfileWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const ModalInputWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin: 0 auto;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const ModalInput = styled(Input)`
+  border-radius: 6.25em;
+  border-color: ${Common.colors.main};
+`;
+
+export const ErrorMsg = styled.p`
+  color: red;
+  font-size: 0.8rem;
+  align-self: flex-start;
+`;
+
+export const Title = styled.h1`
+  font-size: 40px;
+  font-weight: bold;
+  text-align: center;
+`;

--- a/src/pages/UserPage/components/ModifyUserInfo/ModifyUserName.js
+++ b/src/pages/UserPage/components/ModifyUserInfo/ModifyUserName.js
@@ -1,0 +1,137 @@
+// import { modifyUserInfo } from "api/user-api";
+import React, { useEffect, useState } from "react";
+import { Avatar, Button, Text } from "components";
+import { DEFAULT_PROFILE_IMAGE } from "api/url";
+import PropTypes from "prop-types";
+import { useForm } from "react-hook-form";
+import { userLogin } from "api/auth-api";
+import { modifyUserInfo } from "api/user-api";
+import { useSetRecoilState } from "recoil";
+import { userInfo } from "recoil/user";
+import * as S from "./ModifyUserInfo.style";
+
+const propTypes = {
+  token: PropTypes.string.isRequired,
+  user: PropTypes.instanceOf(Object).isRequired,
+  onClose: PropTypes.func,
+};
+const defaultProps = {
+  onClose: () => {},
+};
+
+const ModifyUserName = ({ token, user, onClose }) => {
+  const setUserInfo = useSetRecoilState(userInfo);
+  const [serverError, setServerError] = useState("");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm({
+    mode: "onSubmit",
+    defaultValues: {
+      fullName: "",
+      password: "",
+    },
+  });
+
+  useEffect(() => {
+    reset({
+      fullName: user.fullName,
+      password: "",
+    });
+  }, [user]);
+
+  // 사용자 이름만 변경
+  const onSubmit = async (data) => {
+    const { fullName, password } = data;
+
+    try {
+      setServerError("");
+      // TODO 사용자 정보 변경 API 요청
+      const { email } = user;
+      // 1. 로그인을 통해 해당 사용자의 비밀번호가 맞는지 검사
+      const result = await userLogin(email, password);
+      if (result) {
+        // 2. 비밀번호가 일치한다면 사용자의 정보 변경
+        const response = await modifyUserInfo(token, fullName, email);
+        // 회원정보 변경 완료 시, modal close
+        if (response) {
+          setUserInfo(response.data);
+          onClose();
+        }
+      }
+    } catch (exception) {
+      setServerError(exception.response.data);
+    }
+  };
+
+  return (
+    <S.Form onSubmit={handleSubmit(onSubmit)}>
+      <S.ProfileWrap>
+        <Avatar src={user.image || DEFAULT_PROFILE_IMAGE} size={150} />
+        <Text size="$b3" strong style={{ marginTop: 20 }}>
+          {user.fullName}
+        </Text>
+      </S.ProfileWrap>
+      <S.ModalInputWrap>
+        <S.ModalInput
+          {...register("fullName", {
+            required: {
+              value: true,
+              message: "변경하실 이름을 입력해 주세요!",
+            },
+          })}
+          useIcon={false}
+          placeholder="변경할 이름을 적어주세요😌"
+          width="100%"
+        />
+        {errors.fullName && <S.ErrorMsg>{errors.fullName.message}</S.ErrorMsg>}
+      </S.ModalInputWrap>
+      <S.ModalInputWrap>
+        <S.ModalInput
+          {...register("password", {
+            required: {
+              value: true,
+              message:
+                "정보를 변경하기 위해서는 비밀번호를 반드시 입력해주셔야 합니다!",
+            },
+          })}
+          useIcon={false}
+          placeholder="비밀번호를 입력해주세요."
+          width="100%"
+          type="password"
+        />
+        {errors.password && <S.ErrorMsg>{errors.password.message}</S.ErrorMsg>}
+      </S.ModalInputWrap>
+      <S.ErrorMsg>{serverError}</S.ErrorMsg>
+      <div>
+        <Button
+          type="submit"
+          width={90}
+          height={45}
+          style={{ display: "inline-block", float: "right", marginLeft: 10 }}
+        >
+          저장
+        </Button>
+        <Button
+          type="button"
+          width={90}
+          height={45}
+          color="$main"
+          backgroundColor="$bg_white"
+          border
+          onClick={onClose}
+          style={{ display: "inline-block", float: "right" }}
+        >
+          취소
+        </Button>
+      </div>
+    </S.Form>
+  );
+};
+
+ModifyUserName.propTypes = propTypes;
+ModifyUserName.defaultProps = defaultProps;
+
+export default ModifyUserName;

--- a/src/pages/UserPage/components/ModifyUserInfo/index.js
+++ b/src/pages/UserPage/components/ModifyUserInfo/index.js
@@ -1,0 +1,2 @@
+export { default as ModifyUserName } from "./ModifyUserName";
+export { default as ModifyPassword } from "./ModifyPassword";

--- a/src/pages/UserPage/index.js
+++ b/src/pages/UserPage/index.js
@@ -1,22 +1,20 @@
 import React, { useState, useEffect } from "react";
-import { Image, Text, Avatar, PostList } from "components";
+import { Image, Text, Avatar, PostList, Button, Icon, Modal } from "components";
 import { useParams, useNavigate } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { jwtToken } from "recoil/authentication";
 import { userInfo } from "recoil/user";
 import { getPostByUserId } from "api/post-api";
+import { DEFAULT_COVER_IMAGE, DEFAULT_PROFILE_IMAGE } from "api/url";
 import { getUserInfoById, followUser, unFollowUser } from "api/user-api";
 import ImageButton from "./components/ImageButton";
 import NoPostWrapper from "./components/NoPostList";
 import FollowButton from "./components/FollowButton";
 import * as S from "./UserPage.style";
+import { ModifyUserName, ModifyPassword } from "./components/ModifyUserInfo";
 
 const FONT_COLOR = "$white";
 const FONT_SIZE = 14;
-const DEFAULT_COVER_IMAGE =
-  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Default+Cover+Image.png";
-const DEFAULT_PROFILE_IMAGE =
-  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Profile_Image.png";
 
 function UserPage() {
   const { ID } = useParams();
@@ -27,6 +25,10 @@ function UserPage() {
   const [coverImageHover, setCoverImageHover] = useState(false);
   const [isFollowing, setIsFollowing] = useState(false);
   const [myPost, setMyPost] = useState([]);
+
+  // yeoonju-jane 사용자 정보 변경
+  const [showModifyUserNameModal, setShowModifyUserNameModel] = useState(false);
+  const [showModifyPasswordModal, setModifyPasswordModal] = useState(false);
 
   const myInfo = useRecoilValue(userInfo);
   const setMyInfo = useSetRecoilState(userInfo);
@@ -136,9 +138,16 @@ function UserPage() {
             <Text color={FONT_COLOR} strong size={FONT_SIZE}>
               {userData?.email || ""}
             </Text>
-            <Text color="$black01" strong>
-              {userData?.fullName || ""}
-            </Text>
+            <S.UserNameWrapper>
+              <Text color="$black01" strong>
+                {userData?.fullName || ""}
+              </Text>
+              <Icon
+                name="edit"
+                style={{ marginLeft: 10 }}
+                onClick={() => setShowModifyUserNameModel(true)}
+              />
+            </S.UserNameWrapper>
           </div>
         </S.UserInfoWrapper>
         <S.ExtraInfoWrapper>
@@ -174,6 +183,11 @@ function UserPage() {
               isUnFollow={isFollowing}
             />
           )}
+          {isOwner && (
+            <Button onClick={() => setModifyPasswordModal(true)}>
+              비밀번호 변경
+            </Button>
+          )}
         </S.FollowBlock>
       </S.ImageWrapper>
       <S.Main>
@@ -186,6 +200,28 @@ function UserPage() {
           // eslint-disable-next-line
           <NoPostWrapper isOwner={isOwner} />
         )}
+        <Modal
+          visible={showModifyUserNameModal}
+          onClose={() => setShowModifyUserNameModel(false)}
+          height="auto"
+        >
+          <ModifyUserName
+            token={token}
+            user={userData}
+            onClose={() => setShowModifyUserNameModel(false)}
+          />
+        </Modal>
+        <Modal
+          visible={showModifyPasswordModal}
+          onClose={() => setModifyPasswordModal(false)}
+          height="auto"
+        >
+          <ModifyPassword
+            token={token}
+            user={userData}
+            onClose={() => setModifyPasswordModal(false)}
+          />
+        </Modal>
       </S.Main>
     </>
   );


### PR DESCRIPTION
1. 사용자 이름 변경
- 사용자 페이지에서 사용자 이름에 hover 시, 이름 오른쪽에 icon button 생성
- icon button 클릭 시, 사용자 이름 변경 modal show
- 입력한 비밀번호가 사용자의 비밀번호와 일치해야만 이름 변경 가능
- 사용자 이름 변경 완료 시, modal 창이 닫히고 사용자 정보 업데이트

2. 사용자 비밀번호 변경
- 오른쪽에 보이는 '비밀번호 변겅' 버튼 클릭 시, 비밀번호 변경 modal show
- 현재 비밀번호가 사용자의 비밀번호와 일치해야만 비밀번호 변경 가능
- 비밀번호 변경 완료 시, 로그아웃 후 메인화면으로 이동
- 메인화면에서는 로그인 팝업을 띄워줍니다.