### PR TITLE
post 리스트 요청 API 연동 및 메인 화면에 데이터 바인딩 완료

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,13 +15,15 @@ import {
   isUserAuthenticated,
 } from "recoil/authentication";
 import { userInfo } from "recoil/user";
-import { postManager } from "recoil/post";
+import { getAllPosts } from "api/post-api";
+import { allPost } from "recoil/post";
 import { Footer } from "components";
-import getAllPost from "repository/postRepository";
 import { MainPage, PostListPage, UserPage } from "./pages";
 
+import "./utils/date";
+
 function App() {
-  const setPosts = useSetRecoilState(postManager);
+  const setPosts = useSetRecoilState(allPost);
   const [isLogined, setIsLogined] = useRecoilState(loginStatus);
   const TokenExist = useRecoilValue(isTokenExist);
   const {
@@ -33,7 +35,6 @@ function App() {
     if (!isLogined && TokenExist) {
       if (isTokenValid) {
         setIsLogined(true);
-        console.log(userData);
         setUserInfo(userData);
       }
     }
@@ -42,7 +43,7 @@ function App() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const posts = await getAllPost();
+        const posts = await getAllPosts();
         setPosts(posts);
       } catch (exception) {
         console.log("error", exception);

--- a/src/api/post-api.js
+++ b/src/api/post-api.js
@@ -2,25 +2,25 @@ import axios from "axios";
 import {
   BASE_URL,
   DELETE_POST,
-  //   GET_CHANNELS,
+  // GET_CHANNELS,
   GET_CHANNEL_BY_NAME,
   GET_POST,
-  //   GET_POSTS,
+  GET_POSTS,
   UPDATE_POST,
   GET_POST_BY_ID,
   CREATE_POST,
 } from "./url";
 
 import Channel from "../mock/channel.json";
-import Post from "../mock/posts.json";
+// import Post from "../mock/posts.json";
 
 // 채널 목록
 export const getChannels = async () => {
-  //   const res = await axios.get(`${BASE_URL}${GET_CHANNELS}`);
+  // const res = await axios.get(`${BASE_URL}${GET_CHANNELS}`);
   await new Promise((resolve) => {
     setTimeout(resolve, 1000);
   });
-  //   return res
+  // return res;
   return Channel;
 };
 
@@ -32,18 +32,23 @@ export const getChannelsByName = async (channelName) => {
   return res;
 };
 
+// 모든 포스트 목록 요청
+export const getAllPosts = async () => {
+  const res = await axios.get(`${BASE_URL}${GET_POST}`);
+  return res.data ? res.data : res;
+};
+
 // 특정 채널의 포스트 목록
-// export const getPosts = async (channelId, offset, limit) => {
-export const getPosts = async (channeld) => {
-  //   const res = await axios.get(`${BASE_URL}${GET_POSTS}/${channelId}`, {
-  //     offset,
-  //     limit,
-  //   });
-  await new Promise((resolve) => {
-    setTimeout(resolve, 1000);
+export const getPostsByChannel = async (channelId, offset, limit) => {
+  const res = await axios.get(`${BASE_URL}${GET_POSTS}/${channelId}`, {
+    offset,
+    limit,
   });
-  //   return res;
-  return Post.filter((post) => post.channel === channeld);
+  // await new Promise((resolve) => {
+  //   setTimeout(resolve, 1000);
+  // });
+  return res;
+  // return Post.filter((post) => post.channel === channeld);
 };
 
 // post 상세 정보

--- a/src/api/url.js
+++ b/src/api/url.js
@@ -58,3 +58,8 @@ export const GET_CONVERSATION = "/messages/conversations";
 export const GET_MESSAGES = "/messages";
 export const CREATE_MESSAGES = "/messages/create";
 export const SEEN_MESSAGES = "/messages/update-seen";
+
+export const DEFAULT_COVER_IMAGE =
+  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Default+Cover+Image.png";
+export const DEFAULT_PROFILE_IMAGE =
+  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Profile_Image.png";

--- a/src/api/user-api.js
+++ b/src/api/user-api.js
@@ -51,6 +51,12 @@ export const uploadProfileImage = async (file, token) => {
   return res;
 };
 
+/**
+ * 팔로우
+ * @param {*} id 팔로워 당할 사용자
+ * @param {*} token 나
+ * @returns Follow model
+ */
 export const followUser = async (id, token) => {
   if (!id) return {};
   const res = await axios.post(

--- a/src/components/SideBar/SideBar.jsx
+++ b/src/components/SideBar/SideBar.jsx
@@ -35,7 +35,7 @@ const SideBar = ({ margin, padding }) => {
   useEffect(() => {
     async function fetchData() {
       try {
-        const response = await getAllUsers(myData._id);
+        const response = await getAllUsers(myData.following);
         setUsers(response);
       } catch (exception) {
         console.error(exception);

--- a/src/components/SideBar/SideBar.jsx
+++ b/src/components/SideBar/SideBar.jsx
@@ -3,7 +3,9 @@ import Input from "components/Input";
 import InputResult from "components/InputResult";
 import Text from "components/Text";
 import PropTypes from "prop-types";
-import { getUsers } from "api/user-api";
+import getAllUsers from "repository/userRepository";
+import { useRecoilValue } from "recoil";
+import { userInfo } from "recoil/user";
 
 const propTypes = {
   margin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -15,6 +17,7 @@ const defaultProps = {
 };
 
 const SideBar = ({ margin, padding }) => {
+  const myData = useRecoilValue(userInfo);
   const [userKeyword, setUserKeyword] = useState("");
   const [users, setUsers] = useState([]);
   const handleChange = (e) => {
@@ -32,15 +35,15 @@ const SideBar = ({ margin, padding }) => {
   useEffect(() => {
     async function fetchData() {
       try {
-        const response = await getUsers();
-        setUsers(response.data);
+        const response = await getAllUsers(myData._id);
+        setUsers(response);
       } catch (exception) {
         console.error(exception);
       }
     }
 
     fetchData();
-  }, []);
+  }, [myData]);
 
   return (
     <div style={containerStyle}>

--- a/src/pages/MainPage/components/MainGrid/MainGrid.jsx
+++ b/src/pages/MainPage/components/MainGrid/MainGrid.jsx
@@ -21,8 +21,15 @@ const MainGrid = ({ data, mainTitle }) => {
       </S.TextWrapper>
       <FluxRow>
         {data.map((post) => {
-          const { _id, image, title, author, createdAt, likes, comments } =
-            post;
+          const {
+            _id,
+            image,
+            content,
+            author,
+            createdAt,
+            likesNum,
+            commentsNum,
+          } = post;
 
           const handleOnClick = (id) => {
             alert(id);
@@ -33,11 +40,11 @@ const MainGrid = ({ data, mainTitle }) => {
               <S.CardWrapper onClick={() => handleOnClick(_id)}>
                 <MainGridCard
                   src={image}
-                  textChildren={title}
-                  author={author}
+                  textChildren={content.title}
+                  author={author.fullName}
                   createdAt={createdAt}
-                  likesNum={likes.length}
-                  commentsNum={comments.length}
+                  likesNum={likesNum}
+                  commentsNum={commentsNum}
                 />
               </S.CardWrapper>
             </FluxCol>

--- a/src/pages/MainPage/components/MainGrid/MainGridCard.jsx
+++ b/src/pages/MainPage/components/MainGrid/MainGridCard.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Flux, Image, Text, ToggleButton } from "components";
 import likesSvg from "assets/likes.svg";
+import { DEFAULT_COVER_IMAGE } from "api/url";
 import likesClickedSvg from "assets/likes_clicked.svg";
 import commentSvg from "assets/comment.svg";
 import S from "./MainGridCard.style";
@@ -41,7 +42,6 @@ const MainGridCard = ({
   commentsNum,
 }) => {
   const { FluxRow, FluxCol } = Flux;
-
   const wrapperStyle = {
     gap,
     margin,
@@ -51,7 +51,7 @@ const MainGridCard = ({
     <>
       <S.CardWrapper style={wrapperStyle}>
         <S.ImageDiv>
-          <Image src={src} width="100%" height={180} />
+          <Image src={src || DEFAULT_COVER_IMAGE} width="100%" height={180} />
         </S.ImageDiv>
         <Text size={textSize} strong>
           {textChildren}
@@ -60,7 +60,7 @@ const MainGridCard = ({
       <FluxRow padding="0 10px">
         <FluxCol span={9}>
           <Text size="$n1">
-            {author}, {createdAt}
+            {author} / {createdAt.formatDate()}
           </Text>
         </FluxCol>
         <FluxCol span={1.5}>

--- a/src/pages/UserPage/index.js
+++ b/src/pages/UserPage/index.js
@@ -5,6 +5,7 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import { jwtToken } from "recoil/authentication";
 import { userInfo } from "recoil/user";
 import { getPostByUserId } from "api/post-api";
+import { DEFAULT_COVER_IMAGE, DEFAULT_PROFILE_IMAGE } from "api/url";
 import { getUserInfoById, followUser, unFollowUser } from "api/user-api";
 import ImageButton from "./components/ImageButton";
 import NoPostWrapper from "./components/NoPostList";
@@ -13,10 +14,6 @@ import * as S from "./UserPage.style";
 
 const FONT_COLOR = "$white";
 const FONT_SIZE = 14;
-const DEFAULT_COVER_IMAGE =
-  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Default+Cover+Image.png";
-const DEFAULT_PROFILE_IMAGE =
-  "https://mygbs.s3.ap-northeast-2.amazonaws.com/user/Profile_Image.png";
 
 function UserPage() {
   const { ID } = useParams();
@@ -64,7 +61,6 @@ function UserPage() {
     if (myInfo.following && !isOwner) {
       const isFollow =
         myInfo.following.filter((follower) => follower.user === ID).length >= 1;
-      console.log(isFollow);
       setIsFollowing(isFollow);
     }
   }, [ID, myInfo, isOwner]);

--- a/src/recoil/post.js
+++ b/src/recoil/post.js
@@ -2,18 +2,32 @@ import { atom, selector, selectorFamily } from "recoil";
 
 export const postManager = atom({
   key: "posts",
-  default: {},
+  default: [],
 });
 
 export const allPost = selector({
   key: "allPost",
   get: ({ get }) => {
     const state = get(postManager);
-    const data = Object.entries(state).reduce(
-      (result, [, post]) => [...result, ...post.posts],
-      []
-    );
-    return data;
+    return state;
+  },
+  set: ({ set }, newPosts) => {
+    const data = newPosts.map((post) => {
+      let postContent = null;
+      try {
+        postContent = JSON.parse(post.title);
+      } catch (exception) {
+        postContent = "test";
+      }
+      return {
+        ...post,
+        commentsNum: post.comments.length,
+        likesNum: post.likes.length,
+        content: postContent,
+        title: null,
+      };
+    });
+    set(postManager, data);
   },
 });
 
@@ -21,17 +35,13 @@ export const allPost = selector({
 export const mainPost = selector({
   key: "mainPost",
   get: ({ get }) => {
-    const data = get(allPost).map((post) => ({
-      ...post,
-      comments: post.comments.length,
-      likes: post.likes.length,
-    }));
+    const posts = [...get(allPost)];
     // 1. 인기순
-    const popular = data
-      .sort((a, b) => b.likes - a.likes)
+    const popular = posts
+      .sort((a, b) => b.likesNum - a.likesNum)
       .filter((_, index) => index < 6);
     // 2. 최신순
-    const latest = data
+    const latest = posts
       .sort((a, b) => {
         const dateA = new Date(a.createdAt);
         const dateB = new Date(b.createdAt);

--- a/src/repository/postRepository.js
+++ b/src/repository/postRepository.js
@@ -11,14 +11,13 @@ const getAllPost = async () => {
   try {
     // 1. 채널 리스트 요청
     const channelResponse = await getChannels();
-    if (channelResponse) {
+    if (channelResponse && channelResponse.data) {
       const postByChannel = await Promise.all(
         // 각 채널별 post 요청
-        // eslint-disable-next-line no-underscore-dangle
-        channelResponse.map((channel) => getPosts(channel._id))
+        channelResponse.data.map((channel) => getPosts(channel._id))
       );
       // { 채널 이름: 채널 정보 + 포스트 정보 } 객체 변환
-      const posts = channelResponse.reduce(
+      const posts = channelResponse.data.reduce(
         (result, channel, index) => ({
           ...result,
           [channel.name]: { ...channel, posts: postByChannel[index] },

--- a/src/repository/userRepository.js
+++ b/src/repository/userRepository.js
@@ -3,24 +3,27 @@
  */
 // import { getUsers } from "api/user-api";
 
-// mock data
-import users from "../mock/users.json";
+import { getUsers } from "api/user-api";
 
-// const getAllUsers = async (offset, limit) => {
-const getAllUsers = async () => {
+// mock data
+// import users from "../mock/users.json";
+
+const getAllUsers = async (userId, offset, limit) => {
+  // const getAllUsers = async (userId) => {
   try {
     // 1. 사용자 리스트 받아오기
-    // const users = await getUsers(offset, limit);
+    const users = await getUsers(offset, limit);
     // 2. 내가 팔로워하고 있는 사용자인지 확인하는 isFollow flag 추가
-    const response = users.map((user) => {
-      // eslint-disable-next-line no-underscore-dangle
-      const followers = user.followers.map((follower) => follower._id);
-      return {
-        ...user,
-        isFollow: followers.includes("62a5f647d298d0396d7e756c"),
-      };
-    });
-    return response;
+    if (users && users.data) {
+      const response = users.data.map((user) => {
+        return {
+          ...user,
+          isFollow: user.following.includes(userId),
+        };
+      });
+      return response;
+    }
+    return [];
   } catch (exception) {
     console.error(exception);
   }

--- a/src/repository/userRepository.js
+++ b/src/repository/userRepository.js
@@ -8,7 +8,7 @@ import { getUsers } from "api/user-api";
 // mock data
 // import users from "../mock/users.json";
 
-const getAllUsers = async (userId, offset, limit) => {
+const getAllUsers = async (following, offset, limit) => {
   // const getAllUsers = async (userId) => {
   try {
     // 1. 사용자 리스트 받아오기
@@ -18,7 +18,9 @@ const getAllUsers = async (userId, offset, limit) => {
       const response = users.data.map((user) => {
         return {
           ...user,
-          isFollow: user.following.includes(userId),
+          isFollow:
+            following.filter((follower) => follower.user === user._id).length >
+            0,
         };
       });
       return response;

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,19 @@
+/**
+ * date 관련 공통 코드
+ */
+// eslint-disable-next-line no-extend-native
+String.prototype.formatDate = function formatDate() {
+  const date = new Date(this);
+  let month = `${date.getMonth() + 1}`;
+  let day = `${date.getDate()}`;
+  const year = `${date.getFullYear()}`;
+
+  if (month.length < 2) {
+    month = `0${month}`;
+  }
+  if (day.length < 2) {
+    day = `0${day}`;
+  }
+
+  return [year, month, day].join(".");
+};


### PR DESCRIPTION
1. mock 데이터로 처리하던 post 리스트 요청 data layer를
api 연동으로 변경

2. 추가적으로 전체 Post 요청 api가 추가되면서 recoil 단 데이터 가공 작업 코드 변경

3. date fomat extension method 추가
- post의 날짜 데이터가 string으로 전달됨에 따라, 이를 화면에 원하는 방식으로 표현해주기 위해
String prototype에 formatDate 메서드 추가
-> 사용 방법 (string 타입의 날짜 데이터).formatDate();