### PR TITLE
좋아요 버튼 component 및 좋아요/취소 API 연동 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ import {
 } from "recoil/authentication";
 import { userInfo } from "recoil/user";
 import { getAllPosts } from "api/post-api";
-import { allPost } from "recoil/post";
+import { allPost, setLikePost } from "recoil/post";
 import { Footer } from "components";
 import { MainPage, PostListPage, UserPage } from "./pages";
 import Auth from "./hoc";
@@ -25,6 +25,7 @@ import "./utils/date";
 
 function App() {
   const setPosts = useSetRecoilState(allPost);
+  const setLikePosts = useSetRecoilState(setLikePost);
 
   // component
   const MainPageComponent = Auth(MainPage);
@@ -39,25 +40,23 @@ function App() {
   const setUserInfo = useSetRecoilState(userInfo);
 
   useEffect(() => {
-    if (!isLogined && TokenExist) {
-      if (isTokenValid) {
-        setIsLogined(true);
-        setUserInfo(userData);
-      }
-    }
-  }, [isLogined, TokenExist, isTokenValid, userData]);
-
-  useEffect(() => {
     async function fetchData() {
       try {
         const posts = await getAllPosts();
-        setPosts(posts);
+        await setPosts(posts);
+        if (!isLogined && TokenExist) {
+          if (isTokenValid) {
+            setIsLogined(true);
+            setUserInfo(userData);
+            setLikePosts(userData._id);
+          }
+        }
       } catch (exception) {
-        console.log("error", exception);
+        console.error("error", exception);
       }
     }
     fetchData();
-  }, []);
+  }, [isTokenValid]);
 
   return (
     // test 2

--- a/src/api/post-api.js
+++ b/src/api/post-api.js
@@ -118,7 +118,7 @@ export const setLikePost = async (postId, token) => {
     },
     {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `bearer ${token}`,
       },
     }
   );
@@ -128,24 +128,22 @@ export const setLikePost = async (postId, token) => {
 
 /**
  * 특정 포스트 좋아요
- * @param {*} postId 포스트 id
+ * @param {*} likeId 좋아요 Id
  * @param {*} token 현재 로그인 user의 token
  * @returns Like model
  */
-export const setUnLikePost = async (postId, token) => {
+export const setUnLikePost = async (likeId, token) => {
   if (!token) throw Error("token 정보가 올바르지 않습니다.");
 
-  const res = await axios.delete(
-    `${BASE_URL}${DELETE_LIKE}`,
-    {
-      id: postId,
+  console.log(likeId, token);
+  const res = await axios.delete(`${BASE_URL}${DELETE_LIKE}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
     },
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
-  );
+    data: {
+      id: likeId,
+    },
+  });
 
   return res;
 };

--- a/src/api/post-api.js
+++ b/src/api/post-api.js
@@ -9,6 +9,8 @@ import {
   UPDATE_POST,
   GET_POST_BY_ID,
   CREATE_POST,
+  CREATE_LIKE,
+  DELETE_LIKE,
 } from "./url";
 
 import Channel from "../mock/channel.json";
@@ -97,5 +99,53 @@ export const createPost = async (post, token) => {
       "content-type": "multipart/form-data",
     },
   });
+  return res;
+};
+
+/**
+ * 특정 포스트 좋아요
+ * @param {*} postId 포스트 id
+ * @param {*} token 현재 로그인 user의 token
+ * @returns Like model
+ */
+export const setLikePost = async (postId, token) => {
+  if (!token) throw Error("token 정보가 올바르지 않습니다.");
+
+  const res = await axios.post(
+    `${BASE_URL}${CREATE_LIKE}`,
+    {
+      postId,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  return res;
+};
+
+/**
+ * 특정 포스트 좋아요
+ * @param {*} postId 포스트 id
+ * @param {*} token 현재 로그인 user의 token
+ * @returns Like model
+ */
+export const setUnLikePost = async (postId, token) => {
+  if (!token) throw Error("token 정보가 올바르지 않습니다.");
+
+  const res = await axios.post(
+    `${BASE_URL}${DELETE_LIKE}`,
+    {
+      id: postId,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
   return res;
 };

--- a/src/api/post-api.js
+++ b/src/api/post-api.js
@@ -135,7 +135,7 @@ export const setLikePost = async (postId, token) => {
 export const setUnLikePost = async (postId, token) => {
   if (!token) throw Error("token 정보가 올바르지 않습니다.");
 
-  const res = await axios.post(
+  const res = await axios.delete(
     `${BASE_URL}${DELETE_LIKE}`,
     {
       id: postId,

--- a/src/api/post-api.js
+++ b/src/api/post-api.js
@@ -135,7 +135,6 @@ export const setLikePost = async (postId, token) => {
 export const setUnLikePost = async (likeId, token) => {
   if (!token) throw Error("token 정보가 올바르지 않습니다.");
 
-  console.log(likeId, token);
   const res = await axios.delete(`${BASE_URL}${DELETE_LIKE}`, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -22,7 +22,7 @@ const defaultProps = {
   likesNum: 0,
   width: 15,
   height: 15,
-  textSize: "$h1",
+  textSize: "$n1",
   style: {},
 };
 

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { jwtToken } from "recoil/authentication";
 import { setLikePost, setUnLikePost } from "api/post-api";
-import { addLike, getLikeId } from "recoil/post";
+import { addLike, getLikeId, removeLike } from "recoil/post";
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -21,7 +21,8 @@ const defaultProps = {
 const LikeButton = ({ id, isLiked, likesNum }) => {
   const token = useRecoilValue(jwtToken);
   const likeId = useRecoilValue(getLikeId(id));
-  const setLike = useSetRecoilState(addLike);
+  const addLikeState = useSetRecoilState(addLike);
+  const removeLikeState = useSetRecoilState(removeLike);
 
   const handleOnClick = async () => {
     try {
@@ -29,9 +30,9 @@ const LikeButton = ({ id, isLiked, likesNum }) => {
         ? await setUnLikePost(likeId, token)
         : await setLikePost(id, token);
       if (response && response.data) {
-        // setLiked((pre) => !pre);
         const { data } = response;
-        if (!isLiked) setLike({ postId: id, like: data });
+        if (!isLiked) addLikeState({ postId: id, like: data });
+        else removeLikeState({ postId: id, likeId });
         return true;
       }
     } catch (exception) {

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -1,11 +1,12 @@
-import React, { useState } from "react";
+import React from "react";
 import likesSvg from "assets/likes.svg";
 import { Image, ToggleButton } from "components";
 import likesClickedSvg from "assets/likes_clicked.svg";
 import PropTypes from "prop-types";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { jwtToken } from "recoil/authentication";
 import { setLikePost, setUnLikePost } from "api/post-api";
+import { addLike, getLikeId } from "recoil/post";
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -19,15 +20,18 @@ const defaultProps = {
 
 const LikeButton = ({ id, isLiked, likesNum }) => {
   const token = useRecoilValue(jwtToken);
-  const [liked, setLiked] = useState(isLiked);
+  const likeId = useRecoilValue(getLikeId(id));
+  const setLike = useSetRecoilState(addLike);
 
   const handleOnClick = async () => {
     try {
-      const response = liked
-        ? await setUnLikePost(id, token)
+      const response = isLiked
+        ? await setUnLikePost(likeId, token)
         : await setLikePost(id, token);
       if (response && response.data) {
-        setLiked((pre) => !pre);
+        // setLiked((pre) => !pre);
+        const { data } = response;
+        if (!isLiked) setLike({ postId: id, like: data });
         return true;
       }
     } catch (exception) {
@@ -44,7 +48,7 @@ const LikeButton = ({ id, isLiked, likesNum }) => {
       }
       textSize="$n1"
       text={likesNum}
-      initialState={token && liked}
+      initialState={token && isLiked}
     >
       <Image src={likesSvg} width={15} height={15} mode="contain" />
     </ToggleButton>

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -1,0 +1,41 @@
+import React from "react";
+import likesSvg from "assets/likes.svg";
+import { Image, ToggleButton } from "components";
+import likesClickedSvg from "assets/likes_clicked.svg";
+import PropTypes from "prop-types";
+
+const propTypes = {
+  id: PropTypes.string.isRequired,
+  isLiked: PropTypes.bool,
+  likesNum: PropTypes.number,
+};
+const defaultProps = {
+  isLiked: false,
+  likesNum: 0,
+};
+
+const LikeButton = ({ id, isLiked, likesNum }) => {
+  const handleOnClick = () => {
+    console.log(id);
+  };
+
+  return (
+    <ToggleButton
+      disabled={false}
+      onClick={handleOnClick}
+      replaceChildren={
+        <Image src={likesClickedSvg} width={15} height={15} mode="contain" />
+      }
+      textSize="$n1"
+      text={likesNum}
+      initialState={isLiked}
+    >
+      <Image src={likesSvg} width={15} height={15} mode="contain" />
+    </ToggleButton>
+  );
+};
+
+LikeButton.propTypes = propTypes;
+LikeButton.defaultProps = defaultProps;
+
+export default LikeButton;

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -12,13 +12,29 @@ const propTypes = {
   id: PropTypes.string.isRequired,
   isLiked: PropTypes.bool,
   likesNum: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  textSize: PropTypes.string,
+  style: PropTypes.instanceOf(Object),
 };
 const defaultProps = {
   isLiked: false,
   likesNum: 0,
+  width: 15,
+  height: 15,
+  textSize: "$h1",
+  style: {},
 };
 
-const LikeButton = ({ id, isLiked, likesNum }) => {
+const LikeButton = ({
+  id,
+  isLiked,
+  likesNum,
+  width,
+  height,
+  textSize,
+  ...props
+}) => {
   const token = useRecoilValue(jwtToken);
   const likeId = useRecoilValue(getLikeId(id));
   const addLikeState = useSetRecoilState(addLike);
@@ -45,13 +61,19 @@ const LikeButton = ({ id, isLiked, likesNum }) => {
       disabled={false}
       onClick={handleOnClick}
       replaceChildren={
-        <Image src={likesClickedSvg} width={15} height={15} mode="contain" />
+        <Image
+          src={likesClickedSvg}
+          width={width}
+          height={height}
+          mode="contain"
+        />
       }
-      textSize="$n1"
+      textSize={textSize}
       text={likesNum}
       initialState={token && isLiked}
+      style={{ ...props.style }}
     >
-      <Image src={likesSvg} width={15} height={15} mode="contain" />
+      <Image src={likesSvg} width={width} height={height} mode="contain" />
     </ToggleButton>
   );
 };

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import likesSvg from "assets/likes.svg";
 import { Image, ToggleButton } from "components";
 import likesClickedSvg from "assets/likes_clicked.svg";
 import PropTypes from "prop-types";
+import { useRecoilValue } from "recoil";
+import { jwtToken } from "recoil/authentication";
+import { setLikePost, setUnLikePost } from "api/post-api";
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -15,8 +18,21 @@ const defaultProps = {
 };
 
 const LikeButton = ({ id, isLiked, likesNum }) => {
-  const handleOnClick = () => {
-    console.log(id);
+  const token = useRecoilValue(jwtToken);
+  const [liked, setLiked] = useState(isLiked);
+
+  const handleOnClick = async () => {
+    try {
+      const response = liked
+        ? await setUnLikePost(id, token)
+        : await setLikePost(id, token);
+      if (response && response.data) {
+        setLiked((pre) => !pre);
+        return true;
+      }
+    } catch (exception) {
+      console.error(exception);
+    }
   };
 
   return (
@@ -28,7 +44,7 @@ const LikeButton = ({ id, isLiked, likesNum }) => {
       }
       textSize="$n1"
       text={likesNum}
-      initialState={isLiked}
+      initialState={token && liked}
     >
       <Image src={likesSvg} width={15} height={15} mode="contain" />
     </ToggleButton>

--- a/src/components/LikeButton/index.js
+++ b/src/components/LikeButton/index.js
@@ -1,0 +1,3 @@
+import LikeButton from "./LikeButton";
+
+export default LikeButton;

--- a/src/components/Navigation/Login.js
+++ b/src/components/Navigation/Login.js
@@ -30,7 +30,7 @@ function Login({ handleLogin, onClose, changeModalType }) {
       const result = await userLogin(loginId, loginPassWord);
       setToken(result.data.token);
       setUser(result.data.user);
-      setLikePosts(result.data.user.id);
+      setLikePosts(result.data.user._id);
     } catch (error) {
       setServerError(error.response.data);
     }

--- a/src/components/Navigation/Login.js
+++ b/src/components/Navigation/Login.js
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { useSetRecoilState } from "recoil";
 import PropTypes from "prop-types";
 import { userInfo } from "recoil/user";
+import { setLikePost } from "recoil/post";
 import * as Ns from "./Navigation.style";
 import { userLogin } from "../../api/auth-api";
 import { loginProcess } from "../../recoil/authentication";
@@ -18,6 +19,7 @@ function Login({ handleLogin, onClose, changeModalType }) {
   });
   const setToken = useSetRecoilState(loginProcess);
   const setUser = useSetRecoilState(userInfo);
+  const setLikePosts = useSetRecoilState(setLikePost);
 
   const [serverError, setServerError] = useState(null);
 
@@ -28,6 +30,7 @@ function Login({ handleLogin, onClose, changeModalType }) {
       const result = await userLogin(loginId, loginPassWord);
       setToken(result.data.token);
       setUser(result.data.user);
+      setLikePosts(result.data.user.id);
     } catch (error) {
       setServerError(error.response.data);
     }

--- a/src/components/ToggleButton/ToggleButton.jsx
+++ b/src/components/ToggleButton/ToggleButton.jsx
@@ -18,6 +18,7 @@ const propTypes = {
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   gap: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  initialState: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -29,6 +30,7 @@ const defaultProps = {
   disabled: true,
   onClick: undefined,
   gap: 10,
+  initialState: false,
 };
 
 const ToggleButton = ({
@@ -41,8 +43,9 @@ const ToggleButton = ({
   strong,
   disabled,
   gap,
+  initialState,
 }) => {
-  const [clicked, setClicked] = useState(false);
+  const [clicked, setClicked] = useState(initialState);
   const [currentChild, setCurrentChild] = useState(children);
 
   const WrapperStyle = {
@@ -62,7 +65,6 @@ const ToggleButton = ({
 
   useEffect(() => {
     if (!replaceChildren) return;
-
     if (!clicked) {
       setCurrentChild(children);
       return;

--- a/src/components/ToggleButton/ToggleButton.jsx
+++ b/src/components/ToggleButton/ToggleButton.jsx
@@ -58,9 +58,9 @@ const ToggleButton = ({
     fontWeight: strong ? "bold" : undefined,
   };
 
-  const handleClicked = () => {
-    onClick();
-    setClicked(!clicked);
+  const handleClicked = async () => {
+    const response = await onClick();
+    if (response) setClicked(!clicked);
   };
 
   useEffect(() => {

--- a/src/components/ToggleButton/ToggleButton.jsx
+++ b/src/components/ToggleButton/ToggleButton.jsx
@@ -73,6 +73,10 @@ const ToggleButton = ({
     setCurrentChild(replaceChildren);
   }, [clicked]);
 
+  useEffect(() => {
+    setClicked(initialState);
+  }, [initialState]);
+
   return (
     <S.Wrapper onClick={handleClicked} disabled={disabled} style={WrapperStyle}>
       <div>{currentChild}</div>

--- a/src/pages/MainPage/components/MainGrid/MainGrid.jsx
+++ b/src/pages/MainPage/components/MainGrid/MainGrid.jsx
@@ -21,8 +21,8 @@ const MainGrid = ({ data, mainTitle }) => {
         </Text>
       </S.TextWrapper>
       <FluxRow>
-        {data.map((post) => {
-          const {
+        {data.map(
+          ({
             _id,
             image,
             content,
@@ -30,27 +30,29 @@ const MainGrid = ({ data, mainTitle }) => {
             createdAt,
             likesNum,
             commentsNum,
-          } = post;
+            isLiked,
+          }) => {
+            const handleOnClick = (id) => {
+              alert(id);
+            };
 
-          const handleOnClick = (id) => {
-            alert(id);
-          };
-
-          return (
-            <FluxCol key={_id}>
-              <S.CardWrapper onClick={() => handleOnClick(_id)}>
-                <MainGridCard
-                  src={image || DEFAULT_COVER_IMAGE}
-                  textChildren={content.title}
-                  author={author.fullName}
-                  createdAt={createdAt}
-                  likesNum={likesNum}
-                  commentsNum={commentsNum}
-                />
-              </S.CardWrapper>
-            </FluxCol>
-          );
-        })}
+            return (
+              <FluxCol key={_id}>
+                <S.CardWrapper onClick={() => handleOnClick(_id)}>
+                  <MainGridCard
+                    src={image || DEFAULT_COVER_IMAGE}
+                    textChildren={content.title}
+                    author={author.fullName}
+                    createdAt={createdAt}
+                    likesNum={likesNum}
+                    commentsNum={commentsNum}
+                    isLiked={isLiked}
+                  />
+                </S.CardWrapper>
+              </FluxCol>
+            );
+          }
+        )}
       </FluxRow>
     </S.MainGridWrapper>
   );

--- a/src/pages/MainPage/components/MainGrid/MainGrid.jsx
+++ b/src/pages/MainPage/components/MainGrid/MainGrid.jsx
@@ -47,6 +47,7 @@ const MainGrid = ({ data, mainTitle }) => {
                     likesNum={likesNum}
                     commentsNum={commentsNum}
                     isLiked={isLiked}
+                    id={_id}
                   />
                 </S.CardWrapper>
               </FluxCol>

--- a/src/pages/MainPage/components/MainGrid/MainGridCard.jsx
+++ b/src/pages/MainPage/components/MainGrid/MainGridCard.jsx
@@ -16,6 +16,7 @@ const propTypes = {
   createdAt: PropTypes.string,
   likesNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   commentsNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  isLiked: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -27,6 +28,7 @@ const defaultProps = {
   createdAt: "",
   likesNum: 0,
   commentsNum: 0,
+  isLiked: false,
 };
 
 const MainGridCard = ({
@@ -39,6 +41,7 @@ const MainGridCard = ({
   createdAt,
   likesNum,
   commentsNum,
+  isLiked,
 }) => {
   const { FluxRow, FluxCol } = Flux;
   const wrapperStyle = {
@@ -76,6 +79,7 @@ const MainGridCard = ({
             }
             textSize="$n1"
             text={likesNum}
+            initialState={isLiked}
           >
             <Image src={likesSvg} width={15} height={15} mode="contain" />
           </ToggleButton>

--- a/src/pages/MainPage/components/MainGrid/MainGridCard.jsx
+++ b/src/pages/MainPage/components/MainGrid/MainGridCard.jsx
@@ -1,9 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Flux, Image, Text, ToggleButton } from "components";
-import likesSvg from "assets/likes.svg";
-import likesClickedSvg from "assets/likes_clicked.svg";
 import commentSvg from "assets/comment.svg";
+import LikeButton from "components/LikeButton";
 import S from "./MainGridCard.style";
 
 const propTypes = {
@@ -17,6 +16,7 @@ const propTypes = {
   likesNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   commentsNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   isLiked: PropTypes.bool,
+  id: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
@@ -42,6 +42,7 @@ const MainGridCard = ({
   likesNum,
   commentsNum,
   isLiked,
+  id,
 }) => {
   const { FluxRow, FluxCol } = Flux;
   const wrapperStyle = {
@@ -66,23 +67,7 @@ const MainGridCard = ({
           </Text>
         </FluxCol>
         <FluxCol span={1.5}>
-          <ToggleButton
-            disabled={false}
-            onClick={() => console.log("Clicked")}
-            replaceChildren={
-              <Image
-                src={likesClickedSvg}
-                width={15}
-                height={15}
-                mode="contain"
-              />
-            }
-            textSize="$n1"
-            text={likesNum}
-            initialState={isLiked}
-          >
-            <Image src={likesSvg} width={15} height={15} mode="contain" />
-          </ToggleButton>
+          <LikeButton id={id} isLiked={isLiked} likesNum={likesNum} />
         </FluxCol>
         <FluxCol span={1.5}>
           <ToggleButton textSize="$n1" text={commentsNum}>

--- a/src/recoil/post.js
+++ b/src/recoil/post.js
@@ -127,7 +127,7 @@ export const setLikePost = selector({
   },
 });
 
-// 특정 post 좋아요 처리
+// 특정 post의 좋아요 id 요청
 export const getLikeId = selectorFamily({
   key: "like",
   get:
@@ -152,9 +152,29 @@ export const addLike = selector({
     const target = {
       ...posts[targetId],
       likes: [...posts[targetId].likes, like],
+      isLiked: true,
     };
     posts[targetId] = target;
 
+    set(allPost, posts);
+  },
+});
+export const removeLike = selector({
+  key: "removeLike",
+  get: () => {},
+  set: ({ set, get }, { postId, likeId }) => {
+    const posts = [...get(allPost)];
+    const targetId = posts.findIndex((post) => post._id === postId);
+
+    const newLike = [...posts[targetId].likes];
+    const targetLikeId = newLike.findIndex((like) => like._id === likeId);
+    newLike.splice(targetLikeId, 1);
+    const target = {
+      ...posts[targetId],
+      likes: newLike,
+      isLiked: false,
+    };
+    posts[targetId] = target;
     set(allPost, posts);
   },
 });

--- a/src/recoil/post.js
+++ b/src/recoil/post.js
@@ -116,9 +116,8 @@ export const setLikePost = selector({
   set: ({ set, get }, userId) => {
     const newPosts = get(allPost).map((post) => ({
       ...post,
-      isLiked: post.likes.filter((like) => like.user === userId) > 0,
+      isLiked: post.likes.filter((like) => like.user === userId).length > 0,
     }));
-
     set(postManager, newPosts);
   },
 });

--- a/src/recoil/post.js
+++ b/src/recoil/post.js
@@ -116,7 +116,7 @@ export const setLikePost = selector({
   set: ({ set, get }, userId) => {
     const newPosts = get(allPost).map((post) => ({
       ...post,
-      isLiked: post.likes.filter((like) => like.user === userId) >= 0,
+      isLiked: post.likes.filter((like) => like.user === userId) > 0,
     }));
 
     set(postManager, newPosts);

--- a/src/recoil/post.js
+++ b/src/recoil/post.js
@@ -108,3 +108,17 @@ export const postImage = selectorFamily({
       return data.length > 0 && data[0].image ? data[0].image : undefined;
     },
 });
+
+// 각 post like 처리
+export const setLikePost = selector({
+  key: "likePost",
+  get: () => {},
+  set: ({ set, get }, userId) => {
+    const newPosts = get(allPost).map((post) => ({
+      ...post,
+      isLiked: post.likes.filter((like) => like.user === userId) >= 0,
+    }));
+
+    set(postManager, newPosts);
+  },
+});


### PR DESCRIPTION
1. component 
- id, : 좋아요 할 post의 id
- isLiked, : post의 좋아요 상태
- likesNum, : post의 좋아요 개수
- width, : 하트 이미지 가로 길이
- height, : 하트 이미지 세로 길이
- textSize, : 좋아요 개수 글씨 크기
- style : 별도의 추가하고 싶은 style 객체

2. 좋아요 시
- 서버로 해당 Post 좋아요 신청 API를 호출하게 됩니다.
- API 성공 시, 하트 이미지를 바꾸고 recoil에 저장된 post 내 like 배열의 새로운 like 모델을 추가하게 됩니다.

3. 좋아요 취소 시
- 서버로 해당 Post 좋아요 신청 취소 API를 호출하게 됩니다.
- API 선공 시, 하트 이미지를 바꾸고 recoil에 저장된 post 내 like 배열에서 해당 like 모델을 제거합니다.